### PR TITLE
Drop stopwords from Lucene

### DIFF
--- a/volumes.xconf
+++ b/volumes.xconf
@@ -6,7 +6,12 @@
 
         <!-- Lucene index configuration -->
         <lucene>
-            <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
+            <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer">
+                <!-- Specify stop words - or remove them entirely -->
+                <param name="stopwords" type="org.apache.lucene.analysis.util.CharArraySet">
+                    <!--<value>the</value>-->
+                </param>
+            </analyzer>
             <text qname="tei:div"/>
         </lucene>
 


### PR DESCRIPTION
- to enable searches like @awmarrs’ “not found attached” - since “not” is currently dropped both from source data and from query strings

- as discussed just now with @plutonik-a: please test on the dev server, confirming that the size of indexes on disk is not excessive, and deploy to production

Addresses https://github.com/HistoryAtState/hsg-shell/issues/350 for the FRUS collection. Other collections will need the corresponding change to their xconf files.