### PR TITLE
Add strikethrough as text rendering option

### DIFF
--- a/schema/frus.odd
+++ b/schema/frus.odd
@@ -1527,6 +1527,9 @@
                                     <valItem ident="underline">
                                         <gloss>Underline</gloss>
                                     </valItem>
+                                    <valItem ident="strikethrough">
+                                        <gloss>Strikethrough</gloss>
+                                    </valItem>
                                     <valItem ident="sub">
                                         <gloss>Subscript</gloss>
                                     </valItem>

--- a/schema/frus.rnc
+++ b/schema/frus.rnc
@@ -1165,6 +1165,9 @@ hi =
         ## (Underline) 
         "underline"
       | 
+        ## (Strikethrough) 
+        "strikethrough"
+      | 
         ## (Subscript) 
         "sub"
       | 

--- a/schema/frus.sch
+++ b/schema/frus.sch
@@ -166,9 +166,9 @@
         <title>Rend Attribute Value Checks</title>
         <rule context="tei:hi">
             <assert
-                test="./@rend = ('strong', 'italic', 'smallcaps', 'roman', 'underline', 'sub', 'superscript')"
+                test="./@rend = ('strong', 'italic', 'smallcaps', 'roman', 'underline', 'strikethrough', 'sub', 'superscript')"
                     >hi/@rend='<value-of select="@rend"/>' is an invalid value. Only the following
-                values are allowed: strong, italic, smallcaps, roman, underline, sub,
+                values are allowed: strong, italic, smallcaps, roman, underline, strikethrough, sub,
                 superscript</assert>
         </rule>
         <rule context="tei:p">
@@ -552,7 +552,7 @@
                 persNames)</assert>
         </rule>
     </pattern>
-    
+
     <pattern id="milestone-checks">
         <title>Milestone checks</title>
         <rule


### PR DESCRIPTION
Request @joewiz to investigate whether we need to add anything to stylesheets or tagsDecl for proper web rendering of strikethrough phrases

Thank you!

~ @WaxCylinderRevival and @KerryHite 