### PR TITLE
Restructure Schematron for XSpec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ build/*
 schema/remove-classDecl.xsl
 schema/remove-add-classDecl.xsl
 schema/add-dc-namespace-to-root.xsl
+tests/*-result.html
 expath-pkg.xml
 repo.xml

--- a/schema/frus-id-checks.sch
+++ b/schema/frus-id-checks.sch
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" 
+    xmlns:ckbk="http://www.oreilly.com/XSLTCookbook" 
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    queryBinding="xslt3">
+    <title>FRUS TEI Rules - ID checks</title>
+
+    <p>This schematron file contains ID-related rules augmenting frus.sch.</p>
+
+    <ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
+    <ns prefix="frus" uri="http://history.state.gov/frus/ns/1.0"/>
+    <ns prefix="xml" uri="http://www.w3.org/XML/1998/namespace"/>
+    <ns prefix="ckbk" uri="http://www.oreilly.com/XSLTCookbook"/>
+    
+    <!-- Define variables used by other patterns -->
+    <let name="xml-ids" value="//*/@xml:id"/>
+    <let name="vol-ids"
+        value="
+        if (doc-available('https://history.state.gov/services/volume-ids')) then
+        doc('https://history.state.gov/services/volume-ids')//volume-id
+        else
+        doc('volume-ids-snapshot.xml')//volume-id"/>
+    <let name="persName-ids" value="//tei:persName/@xml:id"/>
+    <let name="term-ids" value="//tei:term/@xml:id"/>
+    <let name="rendition-ids" value="//tei:rendition/@xml:id"/>
+    <let name="vol-id" value="/tei:TEI/@xml:id"/>
+    <let name="available-images"
+        value="doc(concat('https://history.state.gov/services/volume-images?volume=', $vol-id))//image"/>
+    
+    <pattern id="filename-id-check">
+        <rule context="/tei:TEI">
+            <assert test="@xml:id">Volume's root element is missing an @xml:id; it should correspond
+                to the volume ID.</assert>
+        </rule>
+        <rule context="/tei:TEI/@xml:id">
+            <let name="basename" value="replace(base-uri(.), '^.*/(.*?)$', '$1')"/>
+            <assert test="$basename = concat(., '.xml')">volume id <value-of select="."/> does not
+                match filename <value-of select="$basename"/></assert>
+            <assert test=". = $vol-ids">Invalid TEI/@xml:id: <value-of select="."/>. No known volume
+                ID corresponds to this volume's @xml:id.</assert>
+        </rule>
+    </pattern>
+    
+    <pattern id="att-rendition-checks">
+        <title>Rendition Attribute Value Checks</title>
+        <rule context="@rendition">
+            <assert
+                test="
+                every $rendition-ref in (tokenize(., '\s+') ! substring-after(., '#'))
+                satisfies $rendition-ref = $rendition-ids"
+                >The rendition ID '<value-of select="."/>' is not defined in the teiHeader's list of
+                renditions: <value-of select="string-join($rendition-ids, ', ')"/></assert>
+        </rule>
+    </pattern>
+    
+    <pattern id="pointer-checks">
+        <title>Ref and Pointer Checks</title>
+        <rule
+            context="tei:ref[starts-with(@target, '#pg') and substring-after(@target, 'pg_') castable as xs:integer and ./preceding-sibling::node()[1] = '–' and ./preceding-sibling::node()[2]/self::tei:ref]">
+            <assert
+                test="xs:integer(substring-after(@target, '#pg_')) gt xs:integer(substring-after(preceding-sibling::node()[2]/@target, '#pg_'))"
+                >Invalid page range: <value-of select="preceding-sibling::node()[2]/@target"
+                />–<value-of select="@target"/> (see #<value-of
+                    select="./ancestor::tei:div[1]/@xml:id"/>
+                <value-of
+                    select="
+                    if (./ancestor::tei:div[1]/@xml:id = 'index') then
+                    concat(' under ', string-join(subsequence(tokenize(./ancestor::tei:item[1], '\s+'), 1, 2), ' '), ',')
+                    else
+                    ()"
+                /> and <value-of select="./preceding::tei:pb[1]/@facs"/>.tif).</assert>
+        </rule>
+        <rule
+            context="tei:ref[starts-with(@target, '#pg') and not(substring-after(@target, 'pg_') castable as xs:integer) and ./preceding-sibling::node()[1] = '–' and ./preceding-sibling::node()[2]/self::tei:ref]">
+            <assert
+                test="xs:integer(ckbk:roman-to-number(substring-after(@target, '#pg_'))) gt xs:integer(ckbk:roman-to-number(substring-after(preceding-sibling::node()[2]/@target, '#pg_')))"
+                >Invalid page range: <value-of select="preceding-sibling::node()[2]/@target"
+                />–<value-of select="@target"/> (<value-of
+                    select="ckbk:roman-to-number(substring-after(preceding-sibling::node()[2]/@target, '#pg_'))"
+                />–<value-of select="ckbk:roman-to-number(substring-after(@target, '#pg_'))"/>;
+                see #<value-of select="./ancestor::tei:div[1]/@xml:id"/>
+                <value-of
+                    select="
+                    if (./ancestor::tei:div[1]/@xml:id = 'index') then
+                    concat(' under ', string-join(subsequence(tokenize(./ancestor::tei:item[1], '\s+'), 1, 2), ' '), ',')
+                    else
+                    ()"
+                /> and <value-of select="./preceding::tei:pb[1]/@facs"/>.tif).</assert>
+        </rule>
+        <rule context="tei:ref[starts-with(@target, 'frus')]">
+            <assert
+                test="
+                if (contains(@target, '#') and substring-before(@target, '#') = $vol-ids) then
+                (substring-before(@target, '#') = $vol-ids and (if (doc-available(concat('../volumes/', substring-before(@target, '#'), '.xml'))) then
+                doc(concat('../volumes/', substring-before(@target, '#'), '.xml'))//*/@xml:id = substring-after(@target, '#')
+                else
+                if (doc-available(concat('../../frus-not-yet-reviewed/volumes/', substring-before(@target, '#'), '.xml'))) then
+                doc(concat('../../frus-not-yet-reviewed/volumes/', substring-before(@target, '#'), '.xml'))//*/@xml:id = substring-after(@target, '#')
+                else (: allow this check to pass if you don't have our exact directory structure :)
+                true()))
+                else
+                @target = $vol-ids"
+                >ref/@target='<value-of select="@target"/>' is an invalid value. No volume's ID
+                and/or target element corresponds to this ref/@target value (or, possibly, the
+                volume has not yet been published).</assert>
+        </rule>
+        <rule context="tei:ref[starts-with(@target, '#')]">
+            <assert test="substring-after(@target, '#') = $xml-ids">ref/@target='<value-of
+                select="@target"/>' is an invalid value. No element's @xml:id corresponds to
+                this value.</assert>
+        </rule>
+        <rule context="tei:ref">
+            <assert
+                test="starts-with(@target, '#') or starts-with(@target, 'http') or starts-with(@target, 'mailto')"
+                >Invalid ref/@target='<value-of select="@target"/>'. If this is an internal
+                cross-reference, it needs a "#" prefix.</assert>
+        </rule>
+        <rule context="tei:persName[starts-with(@corresp, '#')]">
+            <assert test="substring-after(@corresp, '#') = $persName-ids"
+                >persName/@corresp='<value-of select="@corresp"/>' is an invalid value. No
+                persName has been defined with an @xml:id corresponding to this value.</assert>
+        </rule>
+        <rule context="tei:persName[starts-with(@corresp, 'frus')]">
+            <assert
+                test="
+                substring-before(@corresp, '#') = $vol-ids and (if (doc-available(concat('../volumes/', substring-before(@corresp, '#'), '.xml'))) then
+                doc(concat('../volumes/', substring-before(@corresp, '#'), '.xml'))//*/@xml:id = substring-after(@corresp, '#')
+                else
+                if (doc-available(concat('../../frus-not-yet-reviewed/volumes/', substring-before(@corresp, '#'), '.xml'))) then
+                doc(concat('../../frus-not-yet-reviewed/volumes/', substring-before(@corresp, '#'), '.xml'))//*/@xml:id = substring-after(@corresp, '#')
+                else
+                false())"
+                >persName/@corresp='<value-of select="@corresp"/>' is an invalid value. No
+                persName has been defined in that volume with an @xml:id corresponding to this
+                value.</assert>
+        </rule>
+        <rule context="tei:gloss[@target]">
+            <assert test="substring-after(@target, '#') = $term-ids">gloss/@target='<value-of
+                select="@target"/>' is an invalid value. No term has been defined with an
+                @xml:id corresponding to this value.</assert>
+        </rule>
+        <rule context="tei:publicationStmt">
+            <assert test="tei:idno[@type = 'frus'] = $vol-ids">The frus idno must be a defined
+                volume ID</assert>
+        </rule>
+        <rule context="@xml:id">
+            <assert test="if (exists($xml-ids)) then count(index-of($xml-ids, string(.))) eq 1 else true()">@xml:id=<value-of select="."/>. Two
+                elements cannot have the same xml:id attribute.</assert>
+        </rule>
+    </pattern>
+
+
+    <!-- XSL Helper Functions -->
+    
+    <!-- Function to convert from Roman Numerals to Numbers. Adapted from Sal Mangano, XSLT Cookbook 2nd Ed (O'Reilly 2006), pp. 70-72 -->
+    <ckbk:romans>
+        <ckbk:roman value="1">i</ckbk:roman>
+        <ckbk:roman value="1">I</ckbk:roman>
+        <ckbk:roman value="5">v</ckbk:roman>
+        <ckbk:roman value="5">V</ckbk:roman>
+        <ckbk:roman value="10">x</ckbk:roman>
+        <ckbk:roman value="10">X</ckbk:roman>
+        <ckbk:roman value="50">l</ckbk:roman>
+        <ckbk:roman value="50">L</ckbk:roman>
+        <ckbk:roman value="100">c</ckbk:roman>
+        <ckbk:roman value="100">C</ckbk:roman>
+        <ckbk:roman value="500">d</ckbk:roman>
+        <ckbk:roman value="500">D</ckbk:roman>
+        <ckbk:roman value="1000">m</ckbk:roman>
+        <ckbk:roman value="1000">M</ckbk:roman>
+    </ckbk:romans>
+    <xsl:variable name="ckbk:roman-nums" select="document('')/*/*/ckbk:roman"/>
+    <xsl:function name="ckbk:roman-to-number">
+        <xsl:param name="roman"/>
+        <xsl:variable name="valid-roman-chars">
+            <xsl:value-of select="document('')/*/ckbk:romans"/>
+        </xsl:variable>
+        <xsl:choose>
+            <!-- returns true if there are any non-Roman characters in the string -->
+            <xsl:when test="translate($roman, $valid-roman-chars, '')">NaN</xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="ckbk:roman-to-number-impl">
+                    <xsl:with-param name="roman" select="$roman"/>
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+    <xsl:template name="ckbk:roman-to-number-impl">
+        <xsl:param name="roman"/>
+        <xsl:param name="value" select="0"/>
+        <xsl:variable name="len" select="string-length($roman)"/>
+        <xsl:choose>
+            <xsl:when test="not($len)">
+                <xsl:value-of select="$value"/>
+            </xsl:when>
+            <xsl:when test="$len = 1">
+                <xsl:value-of select="$value + $ckbk:roman-nums[. = $roman]/@value"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:variable name="roman-num"
+                    select="$ckbk:roman-nums[. = substring($roman, 1, 1)]"/>
+                <xsl:choose>
+                    <xsl:when
+                        test="$roman-num/following-sibling::ckbk:roman = substring($roman, 2, 1)">
+                        <xsl:call-template name="ckbk:roman-to-number-impl">
+                            <xsl:with-param name="roman" select="substring($roman, 2, $len - 1)"/>
+                            <xsl:with-param name="value" select="$value - $roman-num/@value"/>
+                        </xsl:call-template>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:call-template name="ckbk:roman-to-number-impl">
+                            <xsl:with-param name="roman" select="substring($roman, 2, $len - 1)"/>
+                            <xsl:with-param name="value" select="$value + $roman-num/@value"/>
+                        </xsl:call-template>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+</schema>

--- a/schema/frus-signatures.sch
+++ b/schema/frus-signatures.sch
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" 
+    xmlns:ckbk="http://www.oreilly.com/XSLTCookbook" 
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    queryBinding="xslt3">
+    <title>FRUS TEI Rules - Signature block checks</title>
+
+    <p>This schematron file contains Signature block-related rules augmenting frus.sch.</p>
+
+    <ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
+    <ns prefix="frus" uri="http://history.state.gov/frus/ns/1.0"/>
+    <ns prefix="xml" uri="http://www.w3.org/XML/1998/namespace"/>
+    
+    <pattern id="signed-checks">
+        <title>Signature block checks</title>
+        <rule context="tei:closer">
+            <assert test="not(following-sibling::tei:closer)" id="multiple-closers" role="warn"
+                >Multiple consecutive signature blocks should be combined into a single
+                closer.</assert>
+            <assert test="count(tei:signed) eq 1" id="closer-multiple-signed" role="warn">A closer
+                should only have one child signed element</assert>
+        </rule>
+        <rule context="tei:signed">
+            <assert test="not(@corresp)" id="signed-corresp">The @corresp attribute is not allowed
+                on the signed element; it should be moved to the persName inside the signed
+                element</assert>
+            <assert test=".//tei:persName[not(ancestor::tei:note)]" id="signed-persname">Signature
+                blocks must contain a persName</assert>
+            <assert test="not(.//tei:affiliation)" id="affiliation" role="warn">The affiliation
+                element is not allowed.</assert>
+        </rule>
+        <rule context="tei:signed//tei:persName[not(ancestor::tei:note)]">
+            <assert
+                test="empty(.) or tei:hi[@rend eq 'strong'] or tei:hi[@rend eq 'italic' and contains(normalize-space(.), 'name not declassified')]"
+                role="warn" id="persnames-child-hi-rend-strong">People who signed must be wrapped in
+                a hi/@rend="strong" element</assert>
+            <let name="immediate-following-sibling-node"
+                value="following-sibling::node()[not(name() = ('note', 'lb') or normalize-space(.) eq '')][1]"/>
+            <assert
+                test="empty($immediate-following-sibling-node) or (matches(normalize-space($immediate-following-sibling-node), '^\p{P}*$') or $immediate-following-sibling-node/self::tei:hi/@rend eq 'italic')"
+                id="persnames-siblings-italics">Text following a persName element must be wrapped in
+                a hi/@rend="italic" element, not an affiliation element; be sure any line breaks are
+                marked with lb elements</assert>
+            <let name="immediate-preceding-sibling-text-node"
+                value="preceding-sibling::text()[not(normalize-space(.) eq '')][1]"/>
+            <assert
+                test="empty($immediate-preceding-sibling-text-node) or matches(normalize-space($immediate-preceding-sibling-text-node), '^\p{P}*$')"
+                id="first-name" role="warn">There should be no untagged text nodes in signed
+                elements before a persName.</assert>
+            <let name="following-italicized-text"
+                value="following-sibling::tei:hi[@rend eq 'italic']"/>
+            <let name="following-linebreaks" value="following-sibling::tei:lb"/>
+            <assert
+                test="($following-italicized-text and $following-linebreaks) or (empty($following-italicized-text) and empty($following-linebreaks))"
+                id="insert-linebreaks">Any persName elements followed by italicized text should be
+                separated by lb elements.</assert>
+            <assert
+                test="not(following-sibling::tei:persName) or contains-token(ancestor::tei:signed/@ana, '#signed-exception_multiple-consecutive-persnames')"
+                role="warn" id="persname-multiple">This may need to be adapted to a list/item
+                structure (or given a signed-exception @ana value for multiple consecutive
+                persNames)</assert>
+        </rule>
+    </pattern>
+    
+</schema>

--- a/tests/frus-signatures.xspec
+++ b/tests/frus-signatures.xspec
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:frus="http://history.state.gov/frus/ns/1.0" xmlns:tei="http://www.tei-c.org/ns/1.0"
+    schematron="../schema/frus-signatures.sch">
+    
+    <x:scenario label="signed-corresp">
+        
+        <x:context>
+            <closer xmlns="http://www.tei-c.org/ns/1.0">
+                <signed corresp="#p_RRW_1">
+                    <persName corresp="#p_RRW_1">
+                        <hi rend="strong">Ronald Reagan</hi>
+                    </persName>
+                </signed>
+            </closer>
+        </x:context>
+        
+        <x:scenario label="signed-corresp-assertions">
+            
+            <x:expect-assert label="Flag a signed element with a corresp attribute"
+                id="signed-corresp" location="/tei:closer/tei:signed"/>
+            
+        </x:scenario>
+        
+    </x:scenario>
+    
+    <x:scenario label="signed-persname">
+        
+        <x:context>
+            <closer xmlns="http://www.tei-c.org/ns/1.0">
+                <signed>
+                    <hi rend="strong">Zbigniew </hi>
+                </signed>
+            </closer>
+        </x:context>
+        
+        <x:scenario label="signed-persname-assertions">
+            
+            <x:expect-assert label="Flag a signed element without a persName element"
+                id="signed-persname" location="/tei:closer/tei:signed"/>
+            
+        </x:scenario>
+        
+    </x:scenario>
+    
+    <x:scenario label="persnames-in-notes-do-not-count">
+        
+        <x:context>
+            <closer xmlns="http://www.tei-c.org/ns/1.0">
+                <signed>Paul H. Kreisberg<note>
+                    <persName>Kreisberg</persName> signed “Paul” above his typed
+                    signature.</note>
+                </signed>
+            </closer>
+        </x:context>
+        
+        <x:scenario label="persnames-in-notes-do-not-count-assertions">
+            
+            <x:expect-assert
+                label="Flag a signed element without a persName element discounting persNames in notes"
+                id="signed-persname" location="/tei:closer/tei:signed"/>
+            
+        </x:scenario>
+        
+    </x:scenario>
+    
+    <x:scenario label="persnames-child-hi-rend-strong">
+        
+        <x:context>
+            <closer xmlns="http://www.tei-c.org/ns/1.0">
+                <signed>
+                    <persName corresp="#p_VC_1">Vance</persName>
+                </signed>
+            </closer>
+        </x:context>
+        
+        <x:scenario label="persnames-child-hi-rend-strong-assertions">
+            
+            <x:expect-assert
+                label="Flag a signed element with a persName element that does not contain a hi/@rend=strong child"
+                id="persnames-child-hi-rend-strong" location="/tei:closer/tei:signed/tei:persName"
+                role="warn"/>
+            
+        </x:scenario>
+        
+    </x:scenario>
+    
+    
+    
+    <x:scenario label="persnames-siblings-italics">
+        
+        <x:context>
+            <closer xmlns="http://www.tei-c.org/ns/1.0">
+                <signed>
+                    <persName corresp="#p_BWMJ_1">Walter M. Bastian, Jr.</persName> Deputy Director
+                    (Policy and Plans) </signed>
+            </closer>
+        </x:context>
+        
+        <x:scenario label="persnames-siblings-italics">
+            
+            <x:expect-assert label="Flag all non-italicized text after a persName"
+                id="persnames-siblings-italics" location="/tei:closer/tei:signed/tei:persName"/>
+            
+        </x:scenario>
+        
+    </x:scenario>
+    
+    <x:scenario label="insert-linebreaks">
+        
+        <x:context>
+            <closer xmlns="http://www.tei-c.org/ns/1.0">
+                <signed corresp="#p_BWMJ_1">
+                    <persName corresp="#p_BWMJ_1">Walter M. Bastian, Jr.</persName>
+                    <hi rend="italic">Deputy Director (Policy and Plans)</hi>
+                </signed>
+            </closer>
+        </x:context>
+        
+        <x:scenario label="insert-linebreaks-assertions">
+            
+            <x:expect-assert label="Flag text after persName" id="insert-linebreaks"
+                location="/tei:closer/tei:signed/tei:persName"/>
+            
+        </x:scenario>
+        
+    </x:scenario>
+    
+    <x:scenario label="persname-multiple">
+        
+        <x:context>
+            <closer xmlns="http://www.tei-c.org/ns/1.0">
+                <signed>
+                    <persName>John Buchanan</persName>
+                    <persName>Leo J. Ryan</persName>
+                    <persName>J. Herbert Burke</persName>
+                </signed>
+            </closer>
+        </x:context>
+        
+        <x:scenario label="persname-multiple-assertions">
+            
+            <x:expect-assert
+                label="Flag signed elements with more than one persName discounting persNames in notes"
+                id="persname-multiple" location="/tei:closer/tei:signed/tei:persName[1]" role="warn"/>
+            
+        </x:scenario>
+        
+    </x:scenario>
+    
+    <x:scenario label="signed-multiple">
+        
+        <x:context>
+            <closer xmlns="http://www.tei-c.org/ns/1.0">
+                <signed>Tom Simons</signed>
+                <signed>Jim Timbie</signed>
+                <signed>Karen Puschel</signed>
+            </closer>
+        </x:context>
+        
+        <x:scenario label="signed-multiple-assertions">
+            
+            <x:expect-assert label="Flag closer elements with more than one signed element"
+                id="closer-multiple-signed" location="/tei:closer" role="warn"/>
+            
+        </x:scenario>
+        
+    </x:scenario>
+    
+    <x:scenario label="affiliation">
+        
+        <x:context>
+            <closer xmlns="http://www.tei-c.org/ns/1.0">
+                <signed>
+                    <persName><hi rend="strong">David C. Jones</hi></persName>
+                    <lb/>
+                    <affiliation>Acting Chairman <lb/> Joint Chiefs of Staff</affiliation>
+                </signed>
+            </closer>
+        </x:context>
+        
+        <x:scenario label="affiliation-assertions">
+            
+            <x:expect-assert label="Flag signed elements with child affiliation elements"
+                id="affiliation" location="/tei:closer/tei:signed" role="warn"/>
+            
+        </x:scenario>
+        
+    </x:scenario>
+    
+    <x:scenario label="multiple-closers">
+        
+        <x:context>
+            <div xmlns="http://www.tei-c.org/ns/1.0">
+                <closer>
+                    <signed>
+                        <persName corresp="#p_BH_2"><hi rend="strong">Harold Brown</hi></persName>
+                    </signed>
+                </closer>
+                <closer>
+                    <signed>
+                        <persName corresp="#p_VCR_1"><hi rend="strong">Cyrus Vance</hi></persName>
+                    </signed>
+                </closer>
+            </div>
+        </x:context>
+        
+        <x:scenario label="multiple-closers-assertions">
+            
+            <x:expect-assert
+                label="Flag closers elements with immediately following sibling closers"
+                id="multiple-closers" location="/tei:div/tei:closer[1]" role="warn"/>
+            
+        </x:scenario>
+        
+    </x:scenario>
+    
+    <x:scenario label="first-name">
+        
+        <x:context>
+            <closer xmlns="http://www.tei-c.org/ns/1.0">
+                <signed>Jimmy <persName><hi rend="strong">Carter</hi></persName></signed>
+            </closer>
+        </x:context>
+        
+        <x:scenario label="first-name-assertions">
+            
+            <x:expect-assert label="Flag signed elements with text node before persName"
+                id="first-name" location="/tei:closer/tei:signed/tei:persName" role="warn"/>
+            
+        </x:scenario>
+        
+    </x:scenario>
+    
+</x:description>


### PR DESCRIPTION
Often, XSpec files define their contexts inline. In running these XSpec tests against our frus.sch file, oXygen raised fatal errors. Further investigations showed that these errors were triggered by Schematron patterns in frus.sch that assumed a larger context - such as a full volume stored in a directory of all FRUS TEI files. 

To avoid this error, I have moved those tests that assumed the larger context into “schema/frus-id-checks.sch.” 

Also, to align our Schematron checks with XSpec tests, we will pull patterns that we write tests for out from frus.sch into their own Schematron files. For example, I’ve done this with the closer and signed patterns, which now live in “schema/frus-signatures.sch.” 

As we apply this practice to other patterns with new XSpec tests, be sure that you reference any new .sch files with an `<extends>` element in frus.sch. This will ensure that all checks run when we validate volumes - but still allows the XSpec tests to run with their inline contexts.