### PR TITLE
Change flag level and warning message for mismatched consecutive curl…

### DIFF
--- a/schema/frus.sch
+++ b/schema/frus.sch
@@ -494,10 +494,10 @@
                 />] </assert>
 
             <!-- flag mismatched orientation in pairs of quotes -->
-            <assert test="not(matches(., '[’”][‘“]|[‘“][’”]'))">Mismatched pair of consecutive curly
-                quotes: [<value-of
+            <assert role="warn" test="not(matches(., '[’”][‘“]|[‘“][’”]'))">Mismatched pair of
+                consecutive curly quotes: [<value-of
                     select="string-join(analyze-string(., '([’”][‘“]|[‘“][’”])')/fn:match, '; ')"
-                />]. Fix orientation.</assert>
+                />]. Please confirm correctness or fix orientation.</assert>
 
             <!-- flag spaces surrounding colons and semi-colons -->
             <assert role="warn"


### PR DESCRIPTION
…y quotes

Format and indent
---

A few use case examples:
• songs, such as Trinity College's alma mater “’Neath the Elms"
• quotations and excerpts, “’tis nobler in the mind to suffer" / “’Tis better to be vile than vile esteemed”

(Vendor review need flagged by @KerryHite)