### PR TITLE
Tuttle can pick up collection state after package installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
        fail-fast: false
        matrix:
         # 7.0.0-SNAPSHOT and 6.2.1 created
-         exist-version: [latest, release]
+         exist-version: [release]
 
     steps:
       - name: Maximize build space

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ schema/add-dc-namespace-to-root.xsl
 tests/*-result.html
 expath-pkg.xml
 repo.xml
+gitsha.xml
 .vscode/
 .idea/
 node_modules/

--- a/build.xml
+++ b/build.xml
@@ -27,6 +27,7 @@
                     <token key="title" value="${app.title}"/>
                     <token key="commit-id" value="${git.revision}"/>
                     <token key="commit-time" value="${git.time}"/>
+                    <token key="commit-abbrev" value="${repository.short-revision}"/>
                 </replacetokens>
                 <tokenfilter>
                     <!-- until we move template processing to XSLT, take care with reserved characters -->
@@ -56,7 +57,7 @@
     <target name="git.revision" description="Store git revision in ${repository.version}" if="git.present">
         <exec executable="git" outputproperty="git.revision" failifexecutionfails="false" errorproperty="">
             <arg value="--git-dir=${git.repo.path}"/>
-            <arg value="rev-parse"/>            
+            <arg value="rev-parse"/>
             <arg value="HEAD"/>
         </exec>
         <condition property="repository.version" value="${git.revision}" else="unknown">
@@ -66,7 +67,21 @@
             </and>
         </condition>
         <echo>Git repo: ${repository.version}</echo>
-        
+
+        <exec executable="git" outputproperty="git.short-revision" failifexecutionfails="false" errorproperty="">
+            <arg value="--git-dir=${git.repo.path}"/>
+            <arg value="rev-parse"/>
+            <arg value="--short"/>
+            <arg value="HEAD"/>
+        </exec>
+        <condition property="repository.short-revision" value="${git.short-revision}" else="unknown">
+            <and>
+                <isset property="git.short-revision"/>
+                <length string="${git.short-revision}" trim="yes" length="0" when="greater"/>
+            </and>
+        </condition>
+        <echo>Git repo: ${repository.short-revision}</echo>
+
         <exec executable="git" outputproperty="git.time" failifexecutionfails="false" errorproperty="">
             <arg value="--git-dir=${git.repo.path}"/>
             <arg value="show"/>

--- a/gitsha.xml.tmpl
+++ b/gitsha.xml.tmpl
@@ -1,0 +1,3 @@
+<hash>
+    <value>@commit-abbrev@</value>
+</hash>


### PR DESCRIPTION
By adding a gitsha.xml with the short ref of the commit the package was created from allows
tuttle to immediately know that this collection is properly set up.

Otherwise a costly full update would need to take place which would effectively re-download
the entire contents of the package.
As this operation takes tens of minutes it is important to not do this more often than necessary.

++ additional change ++

In order to reliably get releases exist-db 7.0.0-SNAPSHOT was temporarily removed from the testmatrix.