### PR TITLE
CI improvements

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,13 +3,14 @@
   "plugins": [
     ["@semantic-release/commit-analyzer", {
       "preset": "conventionalcommits",
-      "parserOpts": "./commit-parser-options.js",
+      "presetConfig": "./conventionalcommits.config.cjs",
       "releaseRules": [
         { "type": "!(fix|feat|build|chore|ci|docs|style|refactor|perf|test)", "release": "patch" }
       ]
     }],
     ["@semantic-release/release-notes-generator", {
-      "preset": "conventionalcommits"
+      "preset": "conventionalcommits",
+      "presetConfig": "./conventionalcommits.config.cjs"
     }],
     ["@semantic-release/exec", {
       "prepareCmd": "ant -Dapp.version=${nextRelease.version}"

--- a/.releaserc
+++ b/.releaserc
@@ -9,8 +9,7 @@
       ]
     }],
     ["@semantic-release/release-notes-generator", {
-      "preset": "conventionalcommits",
-      "presetConfig": "./conventionalcommits.config.cjs"
+      "preset": "conventionalcommits"
     }],
     ["@semantic-release/exec", {
       "prepareCmd": "ant -Dapp.version=${nextRelease.version}"

--- a/build.xml
+++ b/build.xml
@@ -71,7 +71,7 @@
         <exec executable="git" outputproperty="git.short-revision" failifexecutionfails="false" errorproperty="">
             <arg value="--git-dir=${git.repo.path}"/>
             <arg value="rev-parse"/>
-            <arg value="--short"/>
+            <arg value="--short=7"/>
             <arg value="HEAD"/>
         </exec>
         <condition property="repository.short-revision" value="${git.short-revision}" else="unknown">

--- a/commit-parser-options.js
+++ b/commit-parser-options.js
@@ -1,7 +1,0 @@
-// Change default header pattern matcher to match headers with no colon.
-// This will make the first __word__ in free-form commit message headers the __type__.
-// With this non-empty type we can do a negated match (the type being anything but
-// one of the other keywords with associated release rules).
-module.exports = {
-    "headerPattern": /^(\w*)(?:\(([\w\$\.\-\* ]*)\))?\:? (.*)$/
-};

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,8 +1,8 @@
 module.exports = { 
-    extends: ['@commitlint/config-conventional'], 
+    extends: ['@commitlint/config-conventional'],
     rules: {
-        'body-max-line-length': [1, 'always', 200],  
+        'body-max-line-length': [1, 'always', 200],
         'type-empty': [1, 'never'],
         'subject-empty': [1, 'never']
-      } 
+    }
 }

--- a/conventionalcommits.config.cjs
+++ b/conventionalcommits.config.cjs
@@ -1,0 +1,3 @@
+module.exports = { 
+    headerPattern: /^(\w*)(?:\(([\w\$\.\-\* ]*)\))?\:? (.*)$/
+}

--- a/conventionalcommits.config.cjs
+++ b/conventionalcommits.config.cjs
@@ -1,3 +1,7 @@
+// Change default header pattern matcher to match headers with no colon.
+// This will make the first __word__ in free-form commit message headers the __type__.
+// With this non-empty type we can do a negated match (the type being anything but
+// one of the other keywords with associated release rules).
 module.exports = { 
     headerPattern: /^(\w*)(?:\(([\w\$\.\-\* ]*)\))?\:? (.*)$/
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "devDependencies": {
     "@commitlint/cli": "^18.4.3",
     "@commitlint/config-conventional": "^18.4.0",
-    "@semantic-release/github": "^9.2.1",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "conventional-changelog-conventionalcommits": "^7.0.2",


### PR DESCRIPTION
- gitsha.xml populated with commit hash with 7 characters (was 8)
- further testing for free-form commits to be recognised as patch releases