### PR TITLE
Suppress date warnings for withheld divs

### DIFF
--- a/schema/dates-only-tertiary-review.sch
+++ b/schema/dates-only-tertiary-review.sch
@@ -25,7 +25,7 @@
 
     <pattern id="div-doc-dateTime">
         <title>Div-level doc-dateTime Checks</title>
-        <rule context="tei:div">
+        <rule context="tei:div[not(ends-with(@type, '-pending'))]">
             <assert role="warn" test="(@frus:doc-dateTime-min and @frus:doc-dateTime-min)">To be
                 ready for online publication and date indexing, all divs should have
                 @frus:doc-dateTime-min and @frus:doc-dateTime-max attributes.</assert>


### PR DESCRIPTION
I believe this is the only change needed to the date enrichment facility to accommodate the new div types for withheld divs. See #336.