### PR TITLE
Improve persons & terms list checks

### DIFF
--- a/repo.xml
+++ b/repo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<meta xmlns="http://exist-db.org/xquery/repo" commit-id="395012ba33b50e9d95d2efa34e5add042fbf6aba" commit-time="1747069876">
+<meta xmlns="http://exist-db.org/xquery/repo" commit-id="b5f99bd9808ac2442a48b3b41b20c5f6b16a8fed" commit-time="1747319944">
     <description>FRUS (data)</description>
     <author>Office of the Historian</author>
     <website>https://history.state.gov</website>

--- a/schema/frus-id-checks.sch
+++ b/schema/frus-id-checks.sch
@@ -24,14 +24,22 @@
     <let name="category-ids" value="//tei:category/@xml:id"/>
     <let name="persNames" value="//tei:persName[@xml:id]"/>
     <let name="persName-ids" value="$persNames/@xml:id"/>
-    <let name="persName-id-bases" value="id('persons')//tei:item/tei:hi[1]/tei:persName[1] ! map {'persName': normalize-space(.), 'id-base': concat('p_', replace(., '[^A-Z]', ''), '_')}"/>
+    <let name="persName-id-bases" value="
+            id('persons')//tei:item/tei:hi[1]/tei:persName[1] ! map {
+                'persName': normalize-space(.),
+                'id-base': concat('p_', replace(., '[^A-Z]', ''), '_')
+            }"/>
     <let name="terms" value="//tei:term[@xml:id]"/>
     <let name="term-ids" value="$terms/@xml:id"/>
-    <let name="term-id-bases" value="id('terms')//tei:item/tei:hi[1]/tei:term[1] ! map {'term': normalize-space(.), 'id-base': concat('t_', replace(., '\W', ''), '_')}"/>
+    <let name="term-id-bases" value="
+            id('terms')//tei:item/tei:hi[1]/tei:term[1] ! map {
+                'term': normalize-space(.),
+                'id-base': concat('t_', replace(., '\W', ''), '_')
+            }"/>
     <let name="rendition-ids" value="//tei:rendition/@xml:id"/>
     <let name="vol-id" value="/tei:TEI/@xml:id"/>
     <let name="xml-ids" value="//*/@xml:id"/>
-    
+
     <pattern id="filename-id-check">
         <rule context="/tei:TEI">
             <assert test="@xml:id">Volume's root element is missing an @xml:id; it should correspond
@@ -120,16 +128,17 @@
             <let name="first-hi" value="parent::tei:hi"/>
             <let name="name-raw" value="normalize-space(.)"/>
             <let name="name" value="
-                if (ends-with($first-hi, ',')) then
-                replace($first-hi, ',$', '')
-                else
-                $first-hi"/>
+                    if (ends-with($first-hi, ',')) then
+                        replace($first-hi, ',$', '')
+                    else
+                        $first-hi"/>
             <let name="id-base" value="concat('p_', replace($name, '[^A-Z]', ''), '_')"/>
             <let name="same-persName-id-bases" value="$persName-id-bases[?id-base eq $id-base]"/>
-            <let name="id-incr" value="(index-of($same-persName-id-bases?persName, $name-raw), 1)[1]"/>
+            <let name="id-incr"
+                value="(index-of($same-persName-id-bases?persName, $name-raw), 1)[1]"/>
             <let name="new-id" value="concat($id-base, $id-incr)"/>
-            <assert sqf:fix="add-persName-xml-id" test="exists(@xml:id)">Missing persName
-                element's @xml:id attribute. Entries in the list of persons must have an @xml:id
+            <assert sqf:fix="add-persName-xml-id" test="exists(@xml:id)">Missing persName element's
+                @xml:id attribute. Entries in the list of persons must have an @xml:id
                 attribute.</assert>
             <sqf:fix id="add-persName-xml-id">
                 <sqf:description>
@@ -143,17 +152,16 @@
             <let name="first-hi" value="parent::tei:hi"/>
             <let name="name-raw" value="normalize-space(.)"/>
             <let name="name" value="
-                if (ends-with($first-hi, ',')) then
-                replace($first-hi, ',$', '')
-                else
-                $first-hi"/>
+                    if (ends-with($first-hi, ',')) then
+                        replace($first-hi, ',$', '')
+                    else
+                        $first-hi"/>
             <let name="id-base" value="concat('t_', replace($name, '\W', ''), '_')"/>
             <let name="same-term-id-bases" value="$term-id-bases[?id-base eq $id-base]"/>
             <let name="id-incr" value="(index-of($same-term-id-bases?term, $name-raw), 1)[1]"/>
             <let name="new-id" value="concat($id-base, $id-incr)"/>
-            <assert sqf:fix="add-term-xml-id" test="exists(@xml:id)">Missing term
-                element's @xml:id attribute. Entries in the list of terms must have an @xml:id
-                attribute.</assert>
+            <assert sqf:fix="add-term-xml-id" test="exists(@xml:id)">Missing term element's @xml:id
+                attribute. Entries in the list of terms must have an @xml:id attribute.</assert>
             <sqf:fix id="add-term-xml-id">
                 <sqf:description>
                     <sqf:title>Add a unique @xml:id (<value-of select="$new-id"/>)</sqf:title>
@@ -199,17 +207,18 @@
 
     <pattern id="image-s3-checks">
         <title>Image Checks</title>
-        <rule context="tei:graphic[@url][not(ancestor::tei:titlePage) and not(ancestor::tei:facsimile)]">
+        <rule
+            context="tei:graphic[@url][not(ancestor::tei:titlePage) and not(ancestor::tei:facsimile)]">
             <assert test="concat(@url, '.png') = $available-images">PNG version of '<value-of
-                select="@url"/>' not found on static.history.state.gov</assert>
+                    select="@url"/>' not found on static.history.state.gov</assert>
             <assert test="concat(@url, '.tif') = $available-images">TIFF version of '<value-of
-                select="@url"/>' not found on static.history.state.gov</assert>
+                    select="@url"/>' not found on static.history.state.gov</assert>
         </rule>
     </pattern>
-    
+
     <pattern id="date-ana-checks">
         <title>Date analysis Pointer Checks</title>
-        
+
         <rule context="tei:date[@ana]">
             <assert test="substring-after(@ana, '#') = $category-ids">date/@ana='<value-of
                     select="@ana"/>' is an invalid value. No category has been defined with an

--- a/schema/frus-id-checks.sch
+++ b/schema/frus-id-checks.sch
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema queryBinding="xslt3" xmlns="http://purl.oclc.org/dsdl/schematron"
     xmlns:ckbk="http://www.oreilly.com/XSLTCookbook"
+    xmlns:sqf="http://www.schematron-quickfix.com/validator/process"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     <title>FRUS TEI Rules - ID checks</title>
 
@@ -12,20 +13,25 @@
     <ns prefix="ckbk" uri="http://www.oreilly.com/XSLTCookbook"/>
 
     <!-- Define variables used by other patterns -->
-    <let name="xml-ids" value="//*/@xml:id"/>
     <let name="vol-ids" value="
             if (doc-available('https://history.state.gov/services/volume-ids')) then
                 doc('https://history.state.gov/services/volume-ids')//volume-id
             else
                 doc('volume-ids-snapshot.xml')//volume-id"/>
-    <let name="persName-ids" value="//tei:persName/@xml:id"/>
-    <let name="term-ids" value="//tei:term/@xml:id"/>
-    <let name="rendition-ids" value="//tei:rendition/@xml:id"/>
-    <let name="vol-id" value="/tei:TEI/@xml:id"/>
-    <let name="category-ids" value="//tei:category/@xml:id"/>
     <let name="available-images"
         value="doc(concat('https://history.state.gov/services/volume-images?volume=', $vol-id))//image"/>
 
+    <let name="category-ids" value="//tei:category/@xml:id"/>
+    <let name="persNames" value="//tei:persName[@xml:id]"/>
+    <let name="persName-ids" value="$persNames/@xml:id"/>
+    <let name="persName-id-bases" value="id('persons')//tei:item/tei:hi[1]/tei:persName[1] ! map {'persName': normalize-space(.), 'id-base': concat('p_', replace(., '[^A-Z]', ''), '_')}"/>
+    <let name="terms" value="//tei:term[@xml:id]"/>
+    <let name="term-ids" value="$terms/@xml:id"/>
+    <let name="term-id-bases" value="id('terms')//tei:item/tei:hi[1]/tei:term[1] ! map {'term': normalize-space(.), 'id-base': concat('t_', replace(., '\W', ''), '_')}"/>
+    <let name="rendition-ids" value="//tei:rendition/@xml:id"/>
+    <let name="vol-id" value="/tei:TEI/@xml:id"/>
+    <let name="xml-ids" value="//*/@xml:id"/>
+    
     <pattern id="filename-id-check">
         <rule context="/tei:TEI">
             <assert test="@xml:id">Volume's root element is missing an @xml:id; it should correspond
@@ -108,6 +114,52 @@
                 test="starts-with(@target, '#') or starts-with(@target, 'http') or starts-with(@target, 'mailto')"
                 >Invalid ref/@target='<value-of select="@target"/>'. If this is an internal
                 cross-reference, it needs a "#" prefix.</assert>
+        </rule>
+        <rule context="id('persons')//tei:item/tei:hi[1]/tei:persName[1]">
+            <p>Ensure persons list persName elements have a unique @xml:id</p>
+            <let name="first-hi" value="parent::tei:hi"/>
+            <let name="name-raw" value="normalize-space(.)"/>
+            <let name="name" value="
+                if (ends-with($first-hi, ',')) then
+                replace($first-hi, ',$', '')
+                else
+                $first-hi"/>
+            <let name="id-base" value="concat('p_', replace($name, '[^A-Z]', ''), '_')"/>
+            <let name="same-persName-id-bases" value="$persName-id-bases[?id-base eq $id-base]"/>
+            <let name="id-incr" value="(index-of($same-persName-id-bases?persName, $name-raw), 1)[1]"/>
+            <let name="new-id" value="concat($id-base, $id-incr)"/>
+            <assert sqf:fix="add-persName-xml-id" test="exists(@xml:id)">Missing persName
+                element's @xml:id attribute. Entries in the list of persons must have an @xml:id
+                attribute.</assert>
+            <sqf:fix id="add-persName-xml-id">
+                <sqf:description>
+                    <sqf:title>Add a unique @xml:id (<value-of select="$new-id"/>)</sqf:title>
+                </sqf:description>
+                <sqf:add match="." node-type="attribute" select="$new-id" target="xml:id"/>
+            </sqf:fix>
+        </rule>
+        <rule context="id('terms')//tei:item/tei:hi[1]/tei:term[1]">
+            <p>Ensure terms list term elements have a unique @xml:id</p>
+            <let name="first-hi" value="parent::tei:hi"/>
+            <let name="name-raw" value="normalize-space(.)"/>
+            <let name="name" value="
+                if (ends-with($first-hi, ',')) then
+                replace($first-hi, ',$', '')
+                else
+                $first-hi"/>
+            <let name="id-base" value="concat('t_', replace($name, '\W', ''), '_')"/>
+            <let name="same-term-id-bases" value="$term-id-bases[?id-base eq $id-base]"/>
+            <let name="id-incr" value="(index-of($same-term-id-bases?term, $name-raw), 1)[1]"/>
+            <let name="new-id" value="concat($id-base, $id-incr)"/>
+            <assert sqf:fix="add-term-xml-id" test="exists(@xml:id)">Missing term
+                element's @xml:id attribute. Entries in the list of terms must have an @xml:id
+                attribute.</assert>
+            <sqf:fix id="add-term-xml-id">
+                <sqf:description>
+                    <sqf:title>Add a unique @xml:id (<value-of select="$new-id"/>)</sqf:title>
+                </sqf:description>
+                <sqf:add match="." node-type="attribute" select="$new-id" target="xml:id"/>
+            </sqf:fix>
         </rule>
         <rule context="tei:persName[starts-with(@corresp, '#')]">
             <assert test="substring-after(@corresp, '#') = $persName-ids"

--- a/schema/frus.sch
+++ b/schema/frus.sch
@@ -86,52 +86,23 @@
                 values are allowed: participants, subject, index, terms, names, toc, references,
                 from, to, simple, sources</assert>
         </rule>
-        <rule context="tei:item[ancestor::tei:div/@xml:id = 'terms' and not(child::tei:list)]">
-            <assert sqf:fix="add-term add-xml-id" test=".//tei:term/@xml:id">Missing term element
-                with @xml:id attribute. Entries in the list of terms &amp; abbreviations must have
-                an @xml:id attribute</assert>
-            <let name="first-hi" value="(.//tei:hi)[1]"/>
-            <let name="term" value="
-                    if (ends-with($first-hi, ',')) then
-                        replace($first-hi, ',$', '')
-                    else
-                        $first-hi"/>
-            <let name="id" value="concat('t_', replace($term, '\W', ''), '_1')"/>
-            <!-- the fix takes two passes. hopefully we'll find a way to do this in a single pass 
-                 see https://www.oxygenxml.com/forum/topic14270.html. -->
-            <sqf:fix id="add-term" use-when="not(.//tei:term)">
-                <sqf:description>
-                    <sqf:title>Add a missing term element</sqf:title>
-                </sqf:description>
-                <sqf:replace match="(.//tei:hi)[1]">
-                    <xsl:element name="tei:hi">
-                        <xsl:attribute name="rend" select="./@rend"/>
-                        <xsl:element name="tei:term">
-                            <xsl:value-of select="$term"/>
-                        </xsl:element>
-                        <xsl:text>,</xsl:text>
-                    </xsl:element>
-                </sqf:replace>
-            </sqf:fix>
-            <sqf:fix id="add-xml-id" use-when="exists(.//tei:term)">
-                <sqf:description>
-                    <sqf:title>Add a missing @xml:id</sqf:title>
-                </sqf:description>
-                <sqf:add match=".//tei:term" node-type="attribute" select="$id" target="xml:id"/>
-            </sqf:fix>
-            <assert test="not(tei:term/tei:hi/@rend = 'strong') and not(ends-with(tei:term, ','))"
-                >Improper nesting of hi and term elements (the hi/@rend=strong tag must surround the
-                term element), and/or improper placement of trailing punctuation mark (the trailing
-                comma must lie outside the term element)</assert>
+        <rule context="tei:term[@xml:id]">
+            <assert test="parent::tei:hi/@rend = 'strong'"
+                >Improper nesting of hi and term (a hi/@rend=strong tag must surround the
+                term element)</assert>
+            <assert test="not(ends-with(., ','))">
+                Improper placement of trailing punctuation mark (the
+                trailing comma must lie outside the term element)
+            </assert>
         </rule>
-        <rule context="tei:item[parent::tei:list/@type = 'persons']">
-            <assert test=".//tei:persName/@xml:id">Missing term element with @xml:id attribute.
-                Entries in the list of terms &amp; abbreviations must have an @xml:id
-                attribute</assert>
-            <assert test="tei:persName/tei:hi/@rend = 'strong' or ends-with(tei:persName, ',')"
-                >Improper nesting of hi and persName (the hi/@rend=strong tag must surround the
-                persName element), and/or improper placement of trailing punctuation mark (the
-                trailing comma must lie outside the persName element)</assert>
+        <rule context="tei:persName[@xml:id]">
+            <assert test="parent::tei:hi/@rend = 'strong'"
+                >Improper nesting of hi and persName (a hi/@rend=strong tag must surround the
+                persName element)</assert>
+            <assert test="not(ends-with(., ','))">
+                Improper placement of trailing punctuation mark (the
+                trailing comma must lie outside the persName element)
+            </assert>
         </rule>
     </pattern>
 

--- a/schema/frus.sch
+++ b/schema/frus.sch
@@ -87,31 +87,24 @@
                 from, to, simple, sources</assert>
         </rule>
         <rule context="tei:term[@xml:id]">
-            <assert test="parent::tei:hi/@rend = 'strong'"
-                >Improper nesting of hi and term (a hi/@rend=strong tag must surround the
-                term element)</assert>
-            <assert test="not(ends-with(., ','))">
-                Improper placement of trailing punctuation mark (the
-                trailing comma must lie outside the term element)
-            </assert>
+            <assert test="parent::tei:hi/@rend = 'strong'">Improper nesting of hi and term (a
+                hi/@rend=strong tag must surround the term element)</assert>
+            <assert test="not(ends-with(., ','))"> Improper placement of trailing punctuation mark
+                (the trailing comma must lie outside the term element) </assert>
         </rule>
         <rule context="tei:persName[@xml:id]">
-            <assert test="parent::tei:hi/@rend = 'strong'"
-                >Improper nesting of hi and persName (a hi/@rend=strong tag must surround the
-                persName element)</assert>
-            <assert test="not(ends-with(., ','))">
-                Improper placement of trailing punctuation mark (the
-                trailing comma must lie outside the persName element)
-            </assert>
+            <assert test="parent::tei:hi/@rend = 'strong'">Improper nesting of hi and persName (a
+                hi/@rend=strong tag must surround the persName element)</assert>
+            <assert test="not(ends-with(., ','))"> Improper placement of trailing punctuation mark
+                (the trailing comma must lie outside the persName element) </assert>
         </rule>
     </pattern>
 
     <pattern id="att-rend-checks">
         <title>Rend Attribute Value Checks</title>
         <rule context="tei:hi">
-            <assert
-                test="@rend or @rendition"
-                >hi elements require a @rend or @rendition attribute</assert>
+            <assert test="@rend or @rendition">hi elements require a @rend or @rendition
+                attribute</assert>
         </rule>
     </pattern>
 
@@ -242,20 +235,25 @@
 
     <pattern id="footnote-id-checks">
         <title>Footnote ID Checks</title>
-        <rule context="tei:note[@xml:id and ancestor::tei:div/@type = ('document', 'document-pending')]">
+        <rule
+            context="tei:note[@xml:id and ancestor::tei:div/@type = ('document', 'document-pending')]">
             <assert test="substring-before(./@xml:id, 'fn') = ./ancestor::tei:div[1]/@xml:id"
                 >Footnote ID mismatch. Document ID portion of footnote @xml:id '<value-of
                     select="./@xml:id"/>' must match its document's @xml:id '<value-of
                     select="./ancestor::tei:div[1]/@xml:id"/>'.</assert>
         </rule>
     </pattern>
-    
+
     <pattern id="footnote-numbering-checks">
-        <rule role="warn" context="tei:note[@n castable as xs:integer]">
+        <rule context="tei:note[@n castable as xs:integer]" role="warn">
             <let name="this" value="."/>
-            <let name="previous-footnote" value="(ancestor::tei:div[1]//tei:note[@n castable as xs:integer][. &lt;&lt; $this])[last()]"/>
-            <assert test="empty($previous-footnote) or xs:integer(@n) eq xs:integer($previous-footnote/@n) + 1"
-                >Footnote numbering mismatch. This is footnote “<value-of select="@n"/>”, but the previous foonote in the document is “<value-of select="$previous-footnote/@n"/>”.</assert>
+            <let name="previous-footnote"
+                value="(ancestor::tei:div[1]//tei:note[@n castable as xs:integer][. &lt;&lt; $this])[last()]"/>
+            <assert
+                test="empty($previous-footnote) or xs:integer(@n) eq xs:integer($previous-footnote/@n) + 1"
+                >Footnote numbering mismatch. This is footnote “<value-of select="@n"/>”, but the
+                previous foonote in the document is “<value-of select="$previous-footnote/@n"
+                />”.</assert>
         </rule>
     </pattern>
 


### PR DESCRIPTION
- move ID-related checks into frus-id-checks.sch
- leave only structural checks in frus.sch
- add schematron quick fixes to add IDs to persName & terms and ensure uniqueness, using legacy rules for assigning IDs within a volume
  - Person:  "p_" + initials + "_1"  (where 1 is changed to 2 if another person has already been assigned this ID in the volume, 2 to 3, and so on)
  - Term: "t_" + capitals + "_1" (where 1 is changed to 2 if another term...)