### PR TITLE
Add xspec showing that non-Zulu timezones are ignored

### DIFF
--- a/.last-modified/tests/frus-dates-sch.xspec
+++ b/.last-modified/tests/frus-dates-sch.xspec
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<last-modified xml:id="tests0x2Ffrus-dates-sch.xspec" seconds_since_epoch="1754508731">2025-08-06T19:32:11Z</last-modified>

--- a/tests/frus-dates-sch.xspec
+++ b/tests/frus-dates-sch.xspec
@@ -47,7 +47,7 @@
         </x:context>
         <x:expect-not-assert id="zulu-timezone-mismatch" label="Expected Zulu indicator passes check"/>
     </x:scenario>
-    <x:scenario label="Zulu indicator with justification passes check">
+    <x:scenario label="Zulu indicator with @ana justification passes check">
         <x:context>
             <dateline xmlns="http://www.tei-c.org/ns/1.0">
                 <date ana="#good-reason" when="1986-06-04T09:55:00+00:00">June 4, 1986, 9:55
@@ -55,6 +55,14 @@
             </dateline>
         </x:context>
         <x:expect-not-assert id="zulu-timezone-mismatch"
-            label="Zulu indicator with justification passes check"/>
+            label="Zulu indicator with @ana justification passes check"/>
+    </x:scenario>
+    <x:scenario label="Non-Zulu timezone indicator passes check">
+        <x:context>
+            <dateline xmlns="http://www.tei-c.org/ns/1.0">
+                <date when="1986-06-04T09:55:00-04:00">June 4, 1986, 9:55 a.m.</date>
+            </dateline>
+        </x:context>
+        <x:expect-not-assert id="zulu-timezone-mismatch" label="Non-Zulu timezone indicator passes check"/>
     </x:scenario>
 </x:description>


### PR DESCRIPTION
... since these values are encoded editorially, based on `dateline/placeName` or other date enrichment actions, as recorded with `@ana` values that point to entries in `shared/frus-dates.xml`.